### PR TITLE
Choose your avatar + vibrate when starting multiplayer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ allprojects {
         // The format here must remain consistent in order for the F-Droid checkupdates bot to pick
         // them up. Normally it just checks the android apps build.gradle or AndroidManifest, but
         // we dynamically inject them via these properties.
-        appVersionCode = 13
-        appVersionName = "0.8.0"
+        appVersionCode = 14
+        appVersionName = "0.9.0"
 
         gdxVersion = '1.10.0'
         kotlinCoroutinesVersion = '1.4.2'

--- a/core/src/com/serwylo/retrowars/RetrowarsGame.kt
+++ b/core/src/com/serwylo/retrowars/RetrowarsGame.kt
@@ -3,13 +3,8 @@ package com.serwylo.retrowars
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Game
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.Screen
 import com.serwylo.retrowars.core.*
 import com.serwylo.retrowars.games.GameDetails
-import com.serwylo.retrowars.games.asteroids.AsteroidsGameScreen
-import com.serwylo.retrowars.net.Player
-import com.serwylo.retrowars.net.RetrowarsClient
-import com.serwylo.retrowars.scoring.saveHighScore
 import com.serwylo.retrowars.utils.Platform
 import java.util.*
 

--- a/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
+++ b/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
@@ -796,6 +796,15 @@ class MultiplayerLobbyScreen(game: RetrowarsGame): Scene2dScreen(game, {
                         Actions.run {
                             countdown.setText((count).toString())
                             count--
+
+                            // Due to this not being the most popular game in the world, there is
+                            // sometimes quite a bit fo waiting in the lobby before being able to
+                            // play a game. During this time, one may duck out for a coffee or cake,
+                            // in which case it is good to be notified that a game is about to start.
+                            // Later on when we implement sounds in the game properly, we can probably
+                            // get rid of this in preference of audio feedback, but with the complete
+                            // absence of audio now, it would sound a bit strange to add it here.
+                            Gdx.input.vibrate(100)
                         },
                         sequence(
                             alpha(0f, 0f), // Start at 0f alpha (hence duration 0f)...

--- a/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
+++ b/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
@@ -25,11 +25,13 @@ import kotlin.system.measureTimeMillis
 
 
 class MultiplayerLobbyScreen(game: RetrowarsGame): Scene2dScreen(game, {
+    Gdx.app.log(TAG, "Returning from lobby to main screen. Will close off any server and/or client connection.")
     close()
     game.showMainMenu()
 }) {
 
     companion object {
+
         const val TAG = "MultiplayerLobby"
         const val STATE_TAG = "MultiplayerLobby - State"
 
@@ -88,6 +90,20 @@ class MultiplayerLobbyScreen(game: RetrowarsGame): Scene2dScreen(game, {
         }
     }
 
+    private fun onBack() {
+        GlobalScope.launch {
+            if (currentState is Splash) {
+                Gdx.app.log(TAG, "Returning from lobby to main screen. Will close off any server and/or client connection.")
+                close()
+                game.showMainMenu()
+            } else {
+                Gdx.app.log(TAG, "Returning from misc multiplayer lobby screen to the main multiplaye rlobby screen. Will close off any server and/or client connection.")
+                close()
+                game.showMultiplayerLobby()
+            }
+        }
+    }
+
     override fun pause() {
         super.pause()
 
@@ -106,11 +122,7 @@ class MultiplayerLobbyScreen(game: RetrowarsGame): Scene2dScreen(game, {
             pad(UI_SPACE)
 
             val heading = makeHeading(strings["multiplayer-lobby.title"], styles, strings) {
-                GlobalScope.launch {
-                    Gdx.app.log(TAG, "Returning from lobby to main screen. Will close off any server and/or client connection.")
-                    close()
-                    game.showMainMenu()
-                }
+                onBack()
             }
 
             add(heading).center()

--- a/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
+++ b/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
@@ -735,7 +735,7 @@ class MultiplayerLobbyScreen(game: RetrowarsGame): Scene2dScreen(game, {
 
         row().space(UI_SPACE)
 
-        val myAvatar = Avatar(players[0], uiAssets)
+        val myAvatar = Avatar(players[0].id, uiAssets)
 
         if (!previousPlayers.any { it.id == players[0].id }) {
             myAvatar.addAction(CustomActions.bounce())
@@ -751,7 +751,7 @@ class MultiplayerLobbyScreen(game: RetrowarsGame): Scene2dScreen(game, {
 
                 row().space(UI_SPACE)
 
-                val avatar = Avatar(player, uiAssets)
+                val avatar = Avatar(player.id, uiAssets)
 
                 if (!previousPlayers.any { it.id == player.id }) {
                     avatar.addAction(CustomActions.bounce())

--- a/core/src/com/serwylo/retrowars/core/NetworkErrorScreen.kt
+++ b/core/src/com/serwylo/retrowars/core/NetworkErrorScreen.kt
@@ -55,6 +55,7 @@ class NetworkErrorScreen(game: RetrowarsGame, code: Int, message: String): Scene
     private fun makeErrorInfo(code: Int, message: String, styles: UiAssets.Styles): Actor = when (code) {
         Network.ErrorCodes.NO_ROOMS_AVAILABLE -> showNoRoomsAvailable(styles)
         Network.ErrorCodes.CLIENT_CLOSED_APP -> showClientClosedApp(styles)
+        Network.ErrorCodes.PLAYER_ID_IN_USE -> showPlayerIdInUse(styles)
         Network.ErrorCodes.SERVER_SHUTDOWN -> showServerShutdown(styles)
         else -> makeTitle(message, styles)
     }
@@ -68,6 +69,12 @@ class NetworkErrorScreen(game: RetrowarsGame, code: Int, message: String): Scene
     private fun showClientClosedApp(styles: UiAssets.Styles) = VerticalGroup().apply {
         space(UI_SPACE * 2)
         addActor(makeTitle("Game must remain open while connected to the server.\nPlease rejoin to continue playing.", styles))
+    }
+
+    private fun showPlayerIdInUse(styles: UiAssets.Styles) = VerticalGroup().apply {
+        space(UI_SPACE * 2)
+        addActor(makeTitle("Your avatar is already in use", styles))
+        addActor(makeDetails("What are the odds?\nSomeone with the exact same avatar as you is already here!\n(Well actually, the odds are 1 in 18446744073709551614)\n\nPlease either change your avatar, or wait until they leave.", styles))
     }
 
     private fun showServerShutdown(styles: UiAssets.Styles) = VerticalGroup().apply {

--- a/core/src/com/serwylo/retrowars/core/OptionsScreen.kt
+++ b/core/src/com/serwylo/retrowars/core/OptionsScreen.kt
@@ -5,10 +5,9 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Align
-import com.serwylo.beatgame.ui.UI_SPACE
-import com.serwylo.beatgame.ui.makeButton
-import com.serwylo.beatgame.ui.makeHeading
+import com.serwylo.beatgame.ui.*
 import com.serwylo.retrowars.RetrowarsGame
+import com.serwylo.retrowars.UiAssets
 import com.serwylo.retrowars.games.GameDetails
 import com.serwylo.retrowars.games.Games
 import com.serwylo.retrowars.input.AsteroidsSoftController
@@ -17,6 +16,7 @@ import com.serwylo.retrowars.input.SoftController
 import com.serwylo.retrowars.input.TetrisSoftController
 import com.serwylo.retrowars.ui.IconButton
 import com.serwylo.retrowars.utils.Options
+import kotlin.random.Random
 
 class OptionsScreen(game: RetrowarsGame): Scene2dScreen(game, { game.showMainMenu() }) {
 
@@ -30,83 +30,214 @@ class OptionsScreen(game: RetrowarsGame): Scene2dScreen(game, { game.showMainMen
         val container = Table().apply {
             setFillParent(true)
             pad(UI_SPACE)
+
+            row().top()
+            add(
+                makeHeading(strings["options.title"], styles, strings) {
+                    game.showMainMenu()
+                }
+            ).expandY()
+
+            row().pad(UI_SPACE)
+            add(
+                CheckBox(strings["options.visual-effects"], skin).apply {
+
+                    isChecked = Options.useVisualEffects()
+
+                    addListener( object: ChangeListener() {
+                        override fun changed(event: ChangeEvent?, actor: Actor?) {
+                            Options.setUseVisualEffects(!Options.useVisualEffects())
+                        }
+                    })
+
+                }
+            )
+
+            row().padTop(UI_SPACE * 2).padBottom(UI_SPACE)
+            add(
+                Label("Controller layouts", styles.label.medium)
+            )
+
+            row()
+            add(
+                HorizontalGroup().apply {
+
+                    addActor(
+                        IconButton(skin, Games.asteroids.icon(sprites)) {
+                            Gdx.app.postRunnable {
+                                game.screen = ControllerSelectScreen(
+                                    game,
+                                    Games.asteroids,
+                                    AsteroidsSoftController.layouts,
+                                ) { index -> AsteroidsSoftController(index, game.uiAssets) }
+                            }
+                        }
+                    )
+
+                    addActor(
+                        IconButton(skin, Games.snake.icon(sprites)) {
+                            Gdx.app.postRunnable {
+                                game.screen = ControllerSelectScreen(
+                                    game,
+                                    Games.snake,
+                                    SnakeSoftController.layouts,
+                                ) { index -> SnakeSoftController(index, game.uiAssets) }
+                            }
+                        }
+                    )
+
+                    addActor(
+                        IconButton(skin, Games.tetris.icon(sprites)) {
+                            Gdx.app.postRunnable {
+                                game.screen = ControllerSelectScreen(
+                                    game,
+                                    Games.tetris,
+                                    TetrisSoftController.layouts,
+                                ) { index -> TetrisSoftController(index, game.uiAssets) }
+                            }
+                        }
+                    )
+
+                }
+            )
+
+            row().padTop(UI_SPACE * 2).padBottom(UI_SPACE)
+            add(
+                Label("Multiplayer Avatar", styles.label.medium)
+            )
+
+            row()
+            val playerId = Options.getPlayerId()
+            val avatar = if (playerId == 0L) {
+                Label("?", game.uiAssets.getStyles().label.medium)
+            } else {
+                Avatar(playerId, game.uiAssets)
+            }
+
+            add(
+                Button(avatar, game.uiAssets.getSkin()).apply {
+                    addListener(object: ChangeListener() {
+                        override fun changed(event: ChangeEvent?, actor: Actor?) {
+                            Gdx.app.postRunnable {
+                                game.screen = AvatarSelectScreen(game)
+                            }
+                        }
+                    })
+                }
+            ).expandY().top()
+
         }
-
-        container.row().top()
-        container.add(
-            makeHeading(strings["options.title"], styles, strings) {
-                game.showMainMenu()
-            }
-        ).expandY()
-
-        container.row().pad(UI_SPACE)
-
-        container.add(
-            CheckBox(strings["options.visual-effects"], skin).apply {
-
-                isChecked = Options.useVisualEffects()
-
-                addListener( object: ChangeListener() {
-                    override fun changed(event: ChangeEvent?, actor: Actor?) {
-                        Options.setUseVisualEffects(!Options.useVisualEffects())
-                    }
-                })
-
-            }
-        )
-
-        container.row().pad(UI_SPACE)
-        container.add(
-            Label("Controller layouts", styles.label.medium)
-        )
-
-        container.row()
-        container.add(
-            HorizontalGroup().apply {
-
-                addActor(
-                    IconButton(skin, Games.asteroids.icon(sprites)) {
-                        Gdx.app.postRunnable {
-                            game.screen = ControllerSelectScreen(
-                                game,
-                                Games.asteroids,
-                                AsteroidsSoftController.layouts,
-                            ) { index -> AsteroidsSoftController(index, game.uiAssets) }
-                        }
-                    }
-                )
-
-                addActor(
-                    IconButton(skin, Games.snake.icon(sprites)) {
-                        Gdx.app.postRunnable {
-                            game.screen = ControllerSelectScreen(
-                                game,
-                                Games.snake,
-                                SnakeSoftController.layouts,
-                            ) { index -> SnakeSoftController(index, game.uiAssets) }
-                        }
-                    }
-                )
-
-                addActor(
-                    IconButton(skin, Games.tetris.icon(sprites)) {
-                        Gdx.app.postRunnable {
-                            game.screen = ControllerSelectScreen(
-                                game,
-                                Games.tetris,
-                                TetrisSoftController.layouts,
-                            ) { index -> TetrisSoftController(index, game.uiAssets) }
-                        }
-                    }
-                )
-
-            }
-        ).expandY().top()
 
         stage.addActor(container)
 
     }
 
+}
+
+class AvatarSelectScreen(
+    game: RetrowarsGame,
+): Scene2dScreen(game, { game.showOptions() }) {
+
+    private var currentPlayerId = Options.getPlayerId()
+
+    init {
+
+        val container = Table().apply {
+            setFillParent(true)
+            pad(UI_SPACE)
+
+            add(
+                makeHeading(
+                    "Choose your avatar",
+                    game.uiAssets.getStyles(),
+                    game.uiAssets.getStrings()
+                ) {
+                    game.showOptions()
+                }
+            ).expandY().top()
+
+            if (currentPlayerId == 0L) {
+
+                row()
+                add(
+                    Label(
+                        "You have not currently chosen an avatar.\nChoose from one of these:",
+                        game.uiAssets.getStyles().label.medium
+                    ).apply {
+                        setAlignment(Align.center)
+                    }
+                )
+
+            } else {
+
+                row()
+                add(Label("Current avatar:", game.uiAssets.getStyles().label.medium))
+
+                row()
+                add(
+                    HorizontalGroup().apply {
+
+                        addActor(Avatar(currentPlayerId, game.uiAssets))
+
+                        addActor(makeSmallButton("Clear", game.uiAssets.getStyles()) {
+                            Options.setPlayerId(0)
+                            Gdx.app.postRunnable {
+                                game.screen = AvatarSelectScreen(game)
+                            }
+                        })
+
+                        addActor(makeSmallButton("Help", game.uiAssets.getStyles()) {
+                            Gdx.net.openURI("https://github.com/retrowars/retrowars/wiki/Avatars")
+                        })
+
+                    }
+                )
+
+                row()
+                add(Label("To change, choose from one of these:", game.uiAssets.getStyles().label.medium))
+
+            }
+
+            row()
+            val avatarGridCell: Cell<Table> = add(makeAvatarGrid(game.uiAssets))
+
+            row()
+            add(
+                makeButton("Show me more", game.uiAssets.getStyles()) {
+                    avatarGridCell.setActor(makeAvatarGrid(game.uiAssets))
+                }
+            ).expandY().top()
+
+        }
+
+        stage.addActor(container)
+    }
+
+    private fun makeAvatarGrid(uiAssets: UiAssets): Table {
+        return Table().apply {
+            for (y in 0 until 2) {
+                row()
+                for (x in 0 until 6) {
+                    val id = Random.nextInt()
+                    add(
+                        Button(
+                            Avatar(id.toLong(), uiAssets),
+                            uiAssets.getSkin(),
+                        ).apply {
+                            addListener(object: ChangeListener() {
+                                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                                    Gdx.app.postRunnable {
+                                        Options.setPlayerId(id.toLong())
+                                        game.screen = OptionsScreen(game)
+                                    }
+                                }
+                            })
+                        }
+                    ).pad(UI_SPACE)
+                }
+            }
+        }
+    }
 }
 
 class ControllerSelectScreen(

--- a/core/src/com/serwylo/retrowars/games/GameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/GameScreen.kt
@@ -308,7 +308,7 @@ abstract class GameScreen(protected val game: RetrowarsGame, private val gameDet
 
     private fun startCameraShake() {
         shakeAnimation.shake()
-        Gdx.input.vibrate(200)
+        Gdx.input.vibrate(300)
     }
 
     private fun shakeCamera(delta: Float) {

--- a/core/src/com/serwylo/retrowars/net/Network.kt
+++ b/core/src/com/serwylo/retrowars/net/Network.kt
@@ -56,6 +56,15 @@ object Network {
           */
         const val CLIENT_CLOSED_APP = 3
 
+        /**
+         * Exceptionally unlikely, but this means that the player ID provided by a client (essentially
+         * the avatar they want to use) is already in use in the current room. I say it is unlikely,
+         * because the game itself only supports randomly choosing [Long] values, so it is probably
+         * only going to happen if someone edits their shared preferences to a specific value that
+         * clashes with someone else.
+         */
+        const val PLAYER_ID_IN_USE = 4
+
     }
 
     /**
@@ -82,9 +91,20 @@ object Network {
 
             @Since(9.0)
             @SerializedName("r")
-            var roomId: Long = 0
+            var roomId: Long = 0,
+
+            /**
+             * Servers may choose to ignore this, and players need not provide this (e.g. if they
+             * wish to remain anonymous to the server by having a new player ID each time). However,
+             * by specifying a playerId, those players are able to ensure they have the same
+             * Avatar each time they rejoin any server, thus making themselves more recognisable
+             * to their friends and themselves.
+             */
+            @Since(14.0)
+            @SerializedName("p")
+            var playerId: Long = 0
         ) {
-            override fun toString() = "RegisterPlayer [app version: $appVersionCode, room id; $roomId]"
+            override fun toString() = "RegisterPlayer [app version: $appVersionCode, room id: $roomId, player id: $playerId]"
         }
 
         class StartGame {

--- a/core/src/com/serwylo/retrowars/net/RetrowarsClient.kt
+++ b/core/src/com/serwylo/retrowars/net/RetrowarsClient.kt
@@ -2,6 +2,7 @@ package com.serwylo.retrowars.net
 
 import com.badlogic.gdx.Gdx
 import com.serwylo.retrowars.utils.AppProperties
+import com.serwylo.retrowars.utils.Options
 import io.ktor.client.*
 import io.ktor.client.features.websocket.*
 import io.ktor.gson.*
@@ -155,7 +156,7 @@ class RetrowarsClient(host: String, port: Int) {
 
         try {
             client.connect(host, port)
-            client.sendMessage(Network.Server.RegisterPlayer(AppProperties.appVersionCode))
+            client.sendMessage(Network.Server.RegisterPlayer(AppProperties.appVersionCode, playerId = Options.getPlayerId()))
         } catch (e: IOException) {
             client.disconnect()
             throw IOException(e)

--- a/core/src/com/serwylo/retrowars/net/RetrowarsServer.kt
+++ b/core/src/com/serwylo/retrowars/net/RetrowarsServer.kt
@@ -420,7 +420,7 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
 
         room.players.remove(player)
 
-        logger.info("Player removed: ${player.id}")
+        logger.info("Player removed: [player id: ${player.id}, room id: ${room.id}]")
 
         if (room.isEmpty()) {
             rooms.remove(room)
@@ -456,7 +456,7 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
 
         connection.player = player
 
-        logger.info("Player added: ${player.id}")
+        logger.info("Player added: [player id: ${player.id}, room id: ${room.id}]")
 
         connection.room = room
 

--- a/core/src/com/serwylo/retrowars/ui/HUD.kt
+++ b/core/src/com/serwylo/retrowars/ui/HUD.kt
@@ -87,7 +87,7 @@ class HUD(private val assets: UiAssets) {
             )
         ).expand().fill()
 
-        avatars = client?.players?.associateWith { Avatar(it, assets) } ?: emptyMap()
+        avatars = client?.players?.associateWith { Avatar(it.id, assets) } ?: emptyMap()
 
         val infoWindow = Table().apply {
             background = assets.getSkin().getDrawable("window")

--- a/core/src/com/serwylo/retrowars/ui/networkUi.kt
+++ b/core/src/com/serwylo/retrowars/ui/networkUi.kt
@@ -39,7 +39,7 @@ fun createPlayerSummaries(me: Player, scores: Map<Player, Long>, showDeaths: Boo
             table.row().space(UI_SPACE).pad(UI_SPACE)
 
             table.add(
-                Avatar(player, assets).apply {
+                Avatar(player.id, assets).apply {
                     isDead = showDeaths && player.status == Player.Status.dead
                 }
             ).right()

--- a/core/src/com/serwylo/retrowars/ui/scene2d.kt
+++ b/core/src/com/serwylo/retrowars/ui/scene2d.kt
@@ -96,7 +96,7 @@ val UI_WIDTH = 800f
 val UI_HEIGHT = 600f
 const val UI_SPACE = 10f
 
-class Avatar(player: Player, uiAssets: UiAssets): Actor() {
+class Avatar(playerId: Long, uiAssets: UiAssets): Actor() {
 
     companion object {
         const val ICON_SIZE = 64f
@@ -116,7 +116,7 @@ class Avatar(player: Player, uiAssets: UiAssets): Actor() {
     var isDead = false
 
     init {
-        val random = Random(player.id)
+        val random = Random(playerId)
 
         beard = sprites.characters.beards.random(random)
         body = sprites.characters.bodies.random(random)

--- a/core/src/com/serwylo/retrowars/utils/Options.kt
+++ b/core/src/com/serwylo/retrowars/utils/Options.kt
@@ -3,10 +3,13 @@ package com.serwylo.retrowars.utils
 import com.badlogic.gdx.Gdx
 import com.serwylo.retrowars.games.GameDetails
 import com.serwylo.retrowars.games.Games
+import kotlin.random.Random
 
 object Options {
 
     private var useVisualEffects: Boolean = prefs().getBoolean("useVisualEffects", true)
+
+    private var playerId: Long = prefs().getLong("playerId", Random.nextLong())
 
     private var softControllers: MutableMap<GameDetails, Int> = Games.allSupported.associateWith {
         prefs().getInteger("${it.id}-softController", 0)
@@ -19,6 +22,15 @@ object Options {
     fun setUseVisualEffects(use: Boolean) {
         prefs().putBoolean("useVisualEffects", use).flush()
         useVisualEffects = use
+    }
+
+    fun getPlayerId(): Long {
+        return playerId
+    }
+
+    fun setPlayerId(value: Long) {
+        prefs().putLong("playerId", value).flush()
+        playerId = value
     }
 
     fun getSoftController(game: GameDetails): Int {

--- a/fastlane/metadata/android/en-US/changelogs/14.txt
+++ b/fastlane/metadata/android/en-US/changelogs/14.txt
@@ -1,0 +1,5 @@
+Improvement:
+ - Allow you to choose an avatar in the options screen, so that each time you connect, you look the same (can opt out by clearing your avatar in options).
+ - Vibrate during countdown to a multiplayer game. For those lonely times where you're waiting in the lobby for others to join, and want to be notified when others are present.
+
+Please donate to support further development.


### PR DESCRIPTION
Improvement:
* Allow you to choose an avatar in the options screen, so that each time you connect, you look the same (can opt out by clearing your avatar in options).
* Vibrate during countdown to a multiplayer game. For those lonely times where you're waiting in the lobby for others to join, and want to be notified when others are present.
