### PR TITLE
More informative summary of server activity. Bump for release v0.22.0.

### DIFF
--- a/android/assets/i18n/messages.properties
+++ b/android/assets/i18n/messages.properties
@@ -61,6 +61,12 @@ multiplayer.server-list.no-servers-found=No servers found
 multiplayer.server-list.unsupported=Unsupported.\nPlease upgrade to at least v{0}.
 multiplayer.server-list.btn.join=Join
 multiplayer.server-list.btn.info=Info
+multiplayer.server-list.num-players={0,choice,1#1 player|1<{0,number,integer} players}
+multiplayer.server-list.last-player-seen.seconds-ago=Active a few seconds ago
+multiplayer.server-list.last-player-seen.minutes-ago=Active a few minutes ago
+multiplayer.server-list.last-player-seen.hours-ago=Active a few hours ago
+multiplayer.server-list.last-player-seen.days-ago=Active a few days ago
+multiplayer.server-list.last-player-seen.a-long-time-ago=No activity for a long time
 
 multiplayer.final-scores.winner=Winner
 multiplayer.final-scores.others=Other

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ allprojects {
         // in order for the F-Droid checkupdates bot to pick them up. Normally it just checks the
         // android apps build.gradle or AndroidManifest, but we dynamically inject them via these
         // properties so that both the server and the client have access to the same information.
-        appVersionCode = 36
-        appVersionName = "0.21.2"
+        appVersionCode = 37
+        appVersionName = "0.22.0"
 
         gdxVersion = '1.10.0'
         kotlinCoroutinesVersion = '1.4.2'

--- a/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
+++ b/core/src/com/serwylo/retrowars/core/MultiplayerLobbyScreen.kt
@@ -15,7 +15,7 @@ import com.serwylo.retrowars.net.*
 import com.serwylo.retrowars.ui.createPlayerSummaries
 import com.serwylo.retrowars.ui.filterActivePlayers
 import com.serwylo.retrowars.ui.makeContributeServerInfo
-import com.serwylo.retrowars.ui.roughTimeAgo
+import com.serwylo.retrowars.ui.playerActivityMessage
 import com.serwylo.retrowars.utils.AppProperties
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -304,7 +304,7 @@ class MultiplayerLobbyScreen(game: RetrowarsGame, serverToConnectTo: ServerHostA
                     )
                 )
 
-                summary = Label("${server.currentPlayerCount} player${if (server.currentPlayerCount == 1) "" else "s"}", styles.label.small)
+                summary = Label(playerActivityMessage(strings, server.currentPlayerCount, server.lastPlayerTimestamp), styles.label.small)
 
                 addActor(summary)
 
@@ -336,16 +336,14 @@ class MultiplayerLobbyScreen(game: RetrowarsGame, serverToConnectTo: ServerHostA
 
             val metadata = Table()
 
-            metadata.add(Label("Last game:", styles.label.small)).left()
-            metadata.add(Label(roughTimeAgo(server.lastGameTimestamp), styles.label.small)).left().padLeft(UI_SPACE)
+            metadata.add(Label(
+                playerActivityMessage(strings, server.currentPlayerCount, server.lastPlayerTimestamp),
+                styles.label.small)
+            ).left().colspan(2)
             metadata.row()
 
             metadata.add(Label("Rooms:", styles.label.small)).left()
             metadata.add(Label("${server.currentRoomCount}/${server.maxRooms}", styles.label.small)).left().padLeft(UI_SPACE)
-            metadata.row()
-
-            metadata.add(Label("Players:", styles.label.small)).left()
-            metadata.add(Label(server.currentPlayerCount.toString(), styles.label.small)).left().padLeft(UI_SPACE)
             metadata.row()
 
             metadata.add(Label("Version:", styles.label.small)).left()
@@ -599,6 +597,7 @@ class MultiplayerLobbyScreen(game: RetrowarsGame, serverToConnectTo: ServerHostA
                         info.currentRoomCount,
                         info.currentPlayerCount,
                         info.lastGameTimestamp,
+                        info.lastPlayerTimestamp,
                         pingTime.toInt(),
                     ))
                 } catch (e: Exception) {
@@ -624,6 +623,7 @@ class MultiplayerLobbyScreen(game: RetrowarsGame, serverToConnectTo: ServerHostA
                         info.currentRoomCount,
                         info.currentPlayerCount,
                         info.lastGameTimestamp,
+                        info.lastPlayerTimestamp,
                         pingTime.toInt(),
                     )).sortedBy { serverDetails ->
                         // We could sort by ping time, but it just isn't the only relevant metric here.

--- a/core/src/com/serwylo/retrowars/net/RetrowarsServer.kt
+++ b/core/src/com/serwylo/retrowars/net/RetrowarsServer.kt
@@ -188,6 +188,7 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
          * reporting to users how often this server is used.
          */
         var lastGame: Date? = null
+        var lastPlayer: Date? = null
 
         fun sendToAll(obj: Any, allConnections: Collection<NetworkServer.Connection>) {
             sendToAllExcept(obj, allConnections, null)
@@ -237,6 +238,7 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
     private var server: NetworkServer
     private var connections = mutableSetOf<NetworkServer.Connection>()
     private var lastGame: Date? = null
+    private var lastPlayer: Date? = null
 
     init {
 
@@ -279,6 +281,7 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
     fun getRoomCount() = rooms.getRoomCount()
     fun getPlayerCount() = rooms.getPlayerCount()
     fun getLastGameTime() = lastGame
+    fun getLastPlayerTime() = lastPlayer
 
     private var returnToLobbyTask: Job? = null
 
@@ -452,6 +455,8 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
             return
         }
 
+        lastPlayer = Date()
+
         val room = rooms.getOrCreateRoom(roomId)
         if (room == null) {
             logger.warn("Request to join room denied, likely because we already have a maximum number of rooms.")
@@ -460,7 +465,6 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
             return
         }
 
-        // TODO: Ensure this ID doesn't already exist on the server.
         if (preferredPlayerId > 0 && room.players.any { it.id == preferredPlayerId }) {
             logger.warn("Request to join room denied. Player with requested ID of $preferredPlayerId already exists in the room.")
             logStats()
@@ -629,6 +633,7 @@ class WebSocketNetworkServer(
                             currentRoomCount = retrowarsServer.getRoomCount(),
                             currentPlayerCount = retrowarsServer.getPlayerCount(),
                             lastGameTimestamp = retrowarsServer.getLastGameTime()?.time ?: -1,
+                            lastPlayerTimestamp = retrowarsServer.getLastPlayerTime()?.time ?: ServerInfoDTO.LAST_PLAYER_TIMESTAMP_NEVER,
                         ))
                     }
                 }

--- a/core/src/com/serwylo/retrowars/net/ServerDirectory.kt
+++ b/core/src/com/serwylo/retrowars/net/ServerDirectory.kt
@@ -76,7 +76,14 @@ data class ServerInfoDTO(
     @Since(9.0)
     val lastGameTimestamp: Long,
 
-)
+    @Since(37.0)
+    val lastPlayerTimestamp: Long = LAST_PLAYER_TIMESTAMP_NEVER,
+
+) {
+    companion object {
+        const val LAST_PLAYER_TIMESTAMP_NEVER = -1L
+    }
+}
 
 /**
  * After fetching the hostname and port from the global server directory, and then using that to
@@ -97,6 +104,7 @@ data class ServerDetails(
     val currentRoomCount: Int,
     val currentPlayerCount: Int,
     val lastGameTimestamp: Long,
+    val lastPlayerTimestamp: Long,
 
     /**
      * Approx ping time - the time it took to ask the server for its details.

--- a/core/src/com/serwylo/retrowars/ui/networkUi.kt
+++ b/core/src/com/serwylo/retrowars/ui/networkUi.kt
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.badlogic.gdx.utils.Align
+import com.badlogic.gdx.utils.I18NBundle
 import com.serwylo.beatgame.ui.*
 import com.serwylo.retrowars.UiAssets
 import com.serwylo.retrowars.games.Games
@@ -128,9 +129,12 @@ fun makeContributeServerInfo(assets: UiAssets) = HorizontalGroup().apply {
     )
 }
 
-fun roughTimeAgo(timestamp: Long): String {
+fun playerActivityMessage(strings: I18NBundle, numPlayers: Int, timestamp: Long): String {
+    if (numPlayers > 0) {
+        return strings.format("multiplayer.server-list.num-players", numPlayers)
+    }
     if (timestamp <= 0) {
-        return "A long time ago"
+        return strings["multiplayer.server-list.last-player-seen.a-long-time-ago"]
     }
 
     val seconds = (System.currentTimeMillis() - timestamp) / 1000
@@ -138,12 +142,13 @@ fun roughTimeAgo(timestamp: Long): String {
     val hours = minutes / 60
     val days = hours / 24
 
-    return when {
-        seconds < 60 -> "Seconds ago"
-        minutes < 60 -> "Minutes ago"
-        hours < 24 -> "Hours ago"
-        days < 30 -> "Days ago"
-        days < 365 -> "Months ago"
-        else -> "Years ago"
-    }
+    return strings[
+        when {
+            seconds < 60 -> "multiplayer.server-list.last-player-seen.seconds-ago"
+            minutes < 60 -> "multiplayer.server-list.last-player-seen.minutes-ago"
+            hours < 24 -> "multiplayer.server-list.last-player-seen.hours-ago"
+            days < 30 -> "multiplayer.server-list.last-player-seen.days-ago"
+            else -> "multiplayer.server-list.last-player-seen.a-long-time-ago"
+        }
+    ]
 }

--- a/fastlane/metadata/android/en-US/changelogs/37.txt
+++ b/fastlane/metadata/android/en-US/changelogs/37.txt
@@ -1,0 +1,5 @@
+Improve feedback about the last time a player tried to play on a server.
+
+There are only a few people playing this game and it is common to join then leave when seeing no other players. Therefore, servers almost always report a "last game" of days or hours ago.
+
+Servers will now the last time a player *tried* to play on the server to let players decide whether to hang around in the lobby or not.


### PR DESCRIPTION
Previously, only active games would show. Given the game is not super popular, these were
few and far between. By instead focussing on the last time a player *joined the server*
rather than the last time *a game was played*, players may be more likely to hang
around for a short period while others join the lobby.

Bump in version number required due to the way we serialize/deserialize server info.
If it remained the same, we wouldn't be able to differentiate ServerInfoDTO objects
between old and new servers.