### PR TITLE
Server: Timeout client connections which have not pinged the server in a certain amount of time.

### DIFF
--- a/server/src/com/serwylo/retrowars/server/ServerApp.kt
+++ b/server/src/com/serwylo/retrowars/server/ServerApp.kt
@@ -17,7 +17,7 @@ class ServerApp(
     private lateinit var server: RetrowarsServer
 
     override fun create() {
-        logger.info("Launching server app [port: ${config.port}, rooms: [type: ${config.rooms.getName()}, maxRooms: ${config.rooms.getMaxRooms()}, roomSize: ${config.rooms.getRoomSize()}], finalScoreDelay: ${config.finalScoreDelay}]")
+        logger.info("Launching server app [port: ${config.port}, rooms: [type: ${config.rooms.getName()}, maxRooms: ${config.rooms.getMaxRooms()}, roomSize: ${config.rooms.getRoomSize()}], finalScoreDelayMillis: ${config.finalScoreDelayMillis}, inactivePlayerTimeoutMillis: ${config.inactivePlayerTimeoutMillis}]")
 
         server = RetrowarsServer(platform, config)
 

--- a/server/src/com/serwylo/retrowars/server/ServerLauncher.kt
+++ b/server/src/com/serwylo/retrowars/server/ServerLauncher.kt
@@ -14,13 +14,15 @@ object ServerLauncher {
         val port = getIntArg("PORT", "port", args) ?: Network.defaultPort
         val maxRooms = getIntArg("MAX_ROOMS", "max-rooms", args) ?: 20
         val roomSize = getIntArg("ROOM_SIZE", "room-size", args) ?: 4
-        val finalScoreDuration = getIntArg("FINAL_SCORE_DURATION", "final-score-duration", args) ?: 7500
+        val finalScoreDurationMillis = getIntArg("FINAL_SCORE_DURATION", "final-score-duration", args) ?: 7500
+        val inactivePlayerTimeoutMillis = getIntArg("INACTIVE_PLAYER_TIMEOUT", "inactive-player-timeout", args) ?: 90000
         val betaGames = getBoolArg("BETA_GAMES", "--beta-games", args)
 
         val serverConfig = RetrowarsServer.Config(
             rooms = RetrowarsServer.Rooms.PublicRandomRooms(roomSize, maxRooms),
             port,
-            finalScoreDuration,
+            finalScoreDurationMillis,
+            inactivePlayerTimeoutMillis,
             includeBetaGames = betaGames,
         )
 


### PR DESCRIPTION
This should help prevent rooms or entire servers being tied up by players who had network connectivity issues.

Defaults to 90 seconds (3 times the expected duration of keep alives from players), but can be configured when starting the server using env variables or arguments.