### PR TITLE
Preload sounds before game.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ allprojects {
         // in order for the F-Droid checkupdates bot to pick them up. Normally it just checks the
         // android apps build.gradle or AndroidManifest, but we dynamically inject them via these
         // properties so that both the server and the client have access to the same information.
-        appVersionCode = 53
-        appVersionName = "0.31.2"
+        appVersionCode = 54
+        appVersionName = "0.31.3"
 
         gdxVersion = '1.10.0'
         kotlinCoroutinesVersion = '1.4.2'

--- a/core/src/com/serwylo/retrowars/audio/SoundLibrary.kt
+++ b/core/src/com/serwylo/retrowars/audio/SoundLibrary.kt
@@ -1,18 +1,17 @@
 package com.serwylo.retrowars.audio
 
+import com.badlogic.gdx.Files
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.assets.loaders.FileHandleResolver
-import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver
 import com.badlogic.gdx.audio.Sound
 import com.badlogic.gdx.files.FileHandle
 import com.serwylo.retrowars.utils.Options
-import io.ktor.server.engine.*
 import kotlinx.coroutines.*
 
 abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
 
-    private val foundSoundFiles = mutableMapOf<String, List<FileHandle>>()
+    private val availableSounds = mutableMapOf<String, List<FileHandle>>()
 
     private val loopingSounds = mutableMapOf<String, Sound>()
     private val loopingSoundIds = mutableMapOf<String, Long>()
@@ -24,22 +23,13 @@ abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
     private val soundScope = CoroutineScope(Dispatchers.IO + soundJob)
 
     protected fun play(soundName: String) {
-        getOrLoadSound(soundName).play(Options.getRealSoundVolume())
+        getSound(soundName).play(Options.getRealSoundVolume())
     }
 
-    private fun getOrLoadSound(soundName: String): Sound {
-        val soundFileName = soundDefinitions[soundName] ?: error("Could not find sound with name: $soundName")
-
-        val cachedFiles = foundSoundFiles[soundName]
-        val file = if (cachedFiles != null) {
-            cachedFiles.random()
-        } else {
-            val files = getSoundFileHandles(soundName, theme, soundFileName)
-            foundSoundFiles[soundName] = files
-            files.random()
-        }
-
-        return assetManager.get(file.path(), Sound::class.java)
+    private fun getSound(soundName: String): Sound {
+        val cachedFiles = availableSounds[soundName] ?: error("Could not find sound(s) with name: $soundName")
+        val file = cachedFiles.random()
+        return assetManager.get(InternalExternalFileHandleResolver.toFileName(file), Sound::class.java)
     }
 
     protected fun startLoop(soundName: String) {
@@ -51,7 +41,7 @@ abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
                 job.cancel()
             }
 
-            getOrLoadSound(soundName).also { sound ->
+            getSound(soundName).also { sound ->
                 loopingSounds[soundName] = sound
 
                 val id = sound.loop(Options.getRealSoundVolume())
@@ -116,11 +106,13 @@ abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
         }
     }
 
-    private val assetManager = AssetManager(InternalFileHandleResolver()).apply {
+    private val assetManager = AssetManager(InternalExternalFileHandleResolver()).apply {
         soundDefinitions.entries.onEach { (soundName, defaultSoundFileName) ->
-            getSoundFileHandles(soundName, theme, defaultSoundFileName).onEach { soundFile ->
-                Gdx.app.log("Loading Sounds", "Queuing sound for loading: ${soundFile}")
-                load(soundFile.path(), Sound::class.java)
+            val files = getSoundFileHandles(soundName, theme, defaultSoundFileName)
+            availableSounds[soundName] = files
+            files.onEach { soundFile ->
+                Gdx.app.log("Loading Sounds", "Queuing sound for loading: $soundFile")
+                load(InternalExternalFileHandleResolver.toFileName(soundFile), Sound::class.java)
             }
         }
     }
@@ -136,6 +128,41 @@ abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
     enum class StopType {
         Immediately,
         FadeFast,
+    }
+
+}
+
+/**
+ * Helper class to differentiate between internal and external file handles when loading via
+ * the [AssetManager].
+ *
+ * This exists because [AssetManager] only knows the [String] path to a file, not a proper [FileHandle].
+ * Furthermore, depending on the platform the game runs on, we don't even know what class an
+ * internal or external file will resolve to.
+ *
+ * Therefore, by first calling [InternalExternalFileHandleResolver.toFileName] this will prefix
+ * the path with "internal:" or "external:". This in turn will be used when loading the asset,
+ * by inspecting the path and looking for the appropriate prefix, and using Gdx.files.internal/external
+ * as appropriate.
+ */
+class InternalExternalFileHandleResolver: FileHandleResolver {
+
+    companion object {
+        fun toFileName(handle: FileHandle): String = "${handle.type().name}:${handle.path()}"
+    }
+
+    override fun resolve(fileName: String): FileHandle {
+        val colon = fileName.indexOf(":")
+        val prefix = fileName.substring(0, colon)
+        val suffix = fileName.substring(colon + 1)
+        return when (prefix) {
+            Files.FileType.Internal.name -> Gdx.files.internal(suffix)
+            Files.FileType.Absolute.name -> Gdx.files.absolute(suffix)
+            Files.FileType.Classpath.name -> Gdx.files.classpath(suffix)
+            Files.FileType.External.name -> Gdx.files.external(suffix)
+            Files.FileType.Local.name -> Gdx.files.local(suffix)
+            else -> error("Unsupported fileName: $fileName. Be sure to call InternalExternalFilehandleResolver.toFileName(FileHandle) to prefix the file path before requesting an asset.")
+        }
     }
 
 }

--- a/core/src/com/serwylo/retrowars/audio/SoundLibrary.kt
+++ b/core/src/com/serwylo/retrowars/audio/SoundLibrary.kt
@@ -23,7 +23,9 @@ abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
     private val soundScope = CoroutineScope(Dispatchers.IO + soundJob)
 
     protected fun play(soundName: String) {
-        getSound(soundName).play(Options.getRealSoundVolume())
+        soundScope.launch {
+            getSound(soundName).play(Options.getRealSoundVolume())
+        }
     }
 
     private fun getSound(soundName: String): Sound {
@@ -41,11 +43,13 @@ abstract class SoundLibrary(private val soundDefinitions: Map<String, String>) {
                 job.cancel()
             }
 
-            getSound(soundName).also { sound ->
-                loopingSounds[soundName] = sound
+            soundScope.launch {
+                getSound(soundName).also { sound ->
+                    loopingSounds[soundName] = sound
 
-                val id = sound.loop(Options.getRealSoundVolume())
-                loopingSoundIds[soundName] = id
+                    val id = sound.loop(Options.getRealSoundVolume())
+                    loopingSoundIds[soundName] = id
+                }
             }
         }
     }

--- a/core/src/com/serwylo/retrowars/games/asteroids/AsteroidsGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/asteroids/AsteroidsGameScreen.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.HorizontalGroup
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.serwylo.beatgame.ui.UI_SPACE
 import com.serwylo.retrowars.RetrowarsGame
+import com.serwylo.retrowars.audio.SoundLibrary
 import com.serwylo.retrowars.games.GameScreen
 import com.serwylo.retrowars.games.Games
 import com.serwylo.retrowars.games.asteroids.entities.Asteroid
@@ -27,6 +28,8 @@ class AsteroidsGameScreen(game: RetrowarsGame) : GameScreen(game, Games.asteroid
     private val lifeContainer = HorizontalGroup().apply { space(UI_SPACE) }
 
     private val sounds = AsteroidsSoundLibrary()
+
+    override fun getSoundLibrary() = sounds
 
     init {
 

--- a/core/src/com/serwylo/retrowars/games/breakout/BreakoutGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/breakout/BreakoutGameScreen.kt
@@ -27,6 +27,7 @@ class BreakoutGameScreen(game: RetrowarsGame): GameScreen(
 
     private val state = BreakoutState(viewport.worldWidth, viewport.worldHeight)
     private val sounds = BreakoutSoundLibrary()
+    override fun getSoundLibrary() = sounds
 
     private val lifeContainer = HorizontalGroup().apply { space(UI_SPACE) }
 

--- a/core/src/com/serwylo/retrowars/games/missilecommand/MissileCommandGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/missilecommand/MissileCommandGameScreen.kt
@@ -22,6 +22,7 @@ class MissileCommandGameScreen(game: RetrowarsGame) : GameScreen(game, Games.mis
 
     private val state = MissileCommandGameState(viewport.worldWidth, viewport.worldHeight)
     private val sounds = MissileCommandSoundLibrary()
+    override fun getSoundLibrary() = sounds
 
     init {
         queueEnemyMissile()

--- a/core/src/com/serwylo/retrowars/games/snake/SnakeGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/snake/SnakeGameScreen.kt
@@ -21,6 +21,7 @@ class SnakeGameScreen(game: RetrowarsGame) : GameScreen(game, Games.snake, 400f,
 
     private val state = SnakeGameState()
     private val sounds = SnakeSoundLibrary()
+    override fun getSoundLibrary() = sounds
 
     override fun show() {
         Gdx.input.inputProcessor = getInputProcessor()

--- a/core/src/com/serwylo/retrowars/games/spaceinvaders/SpaceInvadersGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/spaceinvaders/SpaceInvadersGameScreen.kt
@@ -29,12 +29,12 @@ class SpaceInvadersGameScreen(game: RetrowarsGame) : GameScreen(
     private val lifeContainer = HorizontalGroup().apply { space(UI_SPACE) }
 
     private val sounds = SpaceInvadersSoundLibrary()
+    override fun getSoundLibrary() = sounds
 
     private val barrierTextures: MutableMap<Barrier, Texture> = state.barriers.associateWith { Texture(it.pixmap) }.toMutableMap()
 
     init {
         addGameScoreToHUD(lifeContainer)
-        sounds.tick()
     }
 
     override fun updateGame(delta: Float) {
@@ -43,6 +43,10 @@ class SpaceInvadersGameScreen(game: RetrowarsGame) : GameScreen(
         controller!!.update(delta)
 
         if (getState() == State.Playing) {
+            if (getPreviousState() == State.Loading) {
+                sounds.tick()
+            }
+
             state.isMovingLeft = controller.trigger(SpaceInvadersSoftController.Buttons.LEFT)
             state.isMovingRight = controller.trigger(SpaceInvadersSoftController.Buttons.RIGHT)
             state.isFiring = controller.trigger(SpaceInvadersSoftController.Buttons.FIRE)

--- a/core/src/com/serwylo/retrowars/games/tempest/TempestGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/tempest/TempestGameScreen.kt
@@ -34,6 +34,7 @@ class TempestGameScreen(game: RetrowarsGame) : GameScreen(
 
     private val state = TempestGameState(viewport.worldWidth, viewport.worldHeight)
     private val sounds = TempestSoundLibrary()
+    override fun getSoundLibrary() = sounds
 
     private val lifeContainer = HorizontalGroup().apply { space(UI_SPACE) }
 

--- a/core/src/com/serwylo/retrowars/games/tetris/TetrisGameScreen.kt
+++ b/core/src/com/serwylo/retrowars/games/tetris/TetrisGameScreen.kt
@@ -26,6 +26,7 @@ class TetrisGameScreen(game: RetrowarsGame) : GameScreen(game, Games.tetris, 400
 
     private val state = TetrisGameState()
     private val sounds = TetrisSoundLibrary()
+    override fun getSoundLibrary() = sounds
 
     private val linesLabel = Label("0 lines", game.uiAssets.getStyles().label.large)
 

--- a/fastlane/metadata/android/en-US/changelogs/54.txt
+++ b/fastlane/metadata/android/en-US/changelogs/54.txt
@@ -1,0 +1,1 @@
+Improvement: Load all sounds prior to starting game. Fixes issue with the first sound effect sometimes not playing.


### PR DESCRIPTION
Fixes #105.

Although no formal loading screen is shown (empirically this only takes a fraction of a second), it does politely prevent the game from starting until sounds are ready, in a way that doesn't lock up the phone. In the future if we need to load more assets, then we can think about a more formal "Loading..." experience.