### PR TITLE
Add (partial) Spanish translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Please report any issues or suggest features on the [issue tracker](https://gith
 
 We use [Weblate](https://hosted.weblate.org/engage/retrowars/) to manage translations. Please see [these instructions for using Weblate](https://hosted.weblate.org/engage/retrowars/) to translate retrowars.
 
+> **Note:** After translations are completed in Weblate, a manual change is still required in this code base in order to enable the translation.
+> This will typically be done on your behalf soon after the translation is added, but feel free to log an issue requesting it be done if there are any delays.
+>
+> The technical reason for this delay is because not all glyphs of each font are rendered.
+> Doing so would result in an excessively large game (each font is rendered into PNGs of various font sizes, and fonts such as Google Noto have an impressively large number of glyphs).
+
 |Game strings|F-Droid metadata|
 |------------|----------------|
 |[![Translation status](https://hosted.weblate.org/widgets/retrowars/-/game-strings/multi-auto.svg)](https://hosted.weblate.org/engage/retrowars/)|[![Translation status](https://hosted.weblate.org/widgets/retrowars/-/app-metadata/multi-auto.svg)](https://hosted.weblate.org/engage/retrowars/)|

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ allprojects {
         // in order for the F-Droid checkupdates bot to pick them up. Normally it just checks the
         // android apps build.gradle or AndroidManifest, but we dynamically inject them via these
         // properties so that both the server and the client have access to the same information.
-        appVersionCode = 60
-        appVersionName = "0.31.9"
+        appVersionCode = 61
+        appVersionName = "0.31.10"
 
         gdxVersion = '1.10.0'
         kotlinCoroutinesVersion = '1.4.2'

--- a/core/src/com/serwylo/retrowars/UiAssets.kt
+++ b/core/src/com/serwylo/retrowars/UiAssets.kt
@@ -251,6 +251,7 @@ class UiAssets(private val locale: Locale) {
             "bs" to Font.NOTO_MONO, // ž and other characters not represented by Kenney.
             "de" to Font.KENNEY,
             "en" to Font.KENNEY,
+            "es" to Font.KENNEY,
             "et" to Font.KENNEY,
             "fr" to Font.KENNEY,
             "hu" to Font.NOTO_MONO, // ő and perhaps others are not supported by Kenney.

--- a/fastlane/metadata/android/en-US/changelogs/61.txt
+++ b/fastlane/metadata/android/en-US/changelogs/61.txt
@@ -1,0 +1,5 @@
+More translations!
+
+* Spanish (thanks @Xukula and @gallegonovato)
+
+Want to see this game in your language? Please join us on Weblate to contribute a translation.


### PR DESCRIPTION
Metadata is translated, and the main menu screen is translated. Once this PR is merged, then weblate will perform continuous translation for future updates to the Spanish language.