### PR TITLE
Option to limit server game types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,21 +72,11 @@ We use [Weblate](https://hosted.weblate.org/engage/retrowars/) to manage transla
 
 Pull requests will be warmly received at [https://github.com/retrowars/retrowars](https://github.com/retrowars/retrowars), although it is often easier to first discuss your ideas via the [issue tracker](https://github.com/retrowars/retrowars/issues).
 
-## Running a public server
+## Running a server
 
-If you are able to run a public server, please [see the retrowars-server](https://github.com/retrowars/retrowars-servers/#contributing) project for more details.
-Doing so will make it appear in the default retro wars client when searching for public servers, and ensure that people can continue to play against eachother even if the official servers are down.
+Documentation on running servers can be found at [the retrowars-server project](https://github.com/retrowars/retrowars-servers/#running-a-server).
 
-### Running a server on Heroku
-
-Before pushing to your Heroku app, make sure to set the following config:
-
-```
-heroku config:set GRADLE_TASK="-PexcludeAndroid stage"
-```
-
-Explanation: Newer versions of the Android Gradle plugin require an Android SDK to even configure the `:android` subproject of a libgdx project, not just to compile it.
-To [avoid this issue, run the command above](https://devcenter.heroku.com/articles/deploying-gradle-apps-on-heroku#multiple-application-types-in-the-same-project) to tell Heroku that it doesn't need to worry about configuring anything except the `:core` and `:server` projects, and therefore it doesn't matter that the Android SDK is missing.
+Pull requests to the `retrowars/retrowars-servers` project will allow your server to appear in the default retro wars client when searching for public servers, and ensure that people can continue to play against each other even if the official servers are down.
 
 # Compiling
 

--- a/core/src/com/serwylo/retrowars/net/ServerDirectory.kt
+++ b/core/src/com/serwylo/retrowars/net/ServerDirectory.kt
@@ -132,6 +132,7 @@ private val httpClient = HttpClient(CIO) {
 }
 
 suspend fun fetchPublicServerList(): List<ServerMetadataDTO> {
+    return listOf(ServerMetadataDTO("localhost", 8080))
     val url = "https://retrowars.github.io/retrowars-servers/.well-known/com.serwylo.retrowars-servers.json"
     return httpClient.get(url)
 }

--- a/server/src/com/serwylo/retrowars/server/ServerApp.kt
+++ b/server/src/com/serwylo/retrowars/server/ServerApp.kt
@@ -17,7 +17,7 @@ class ServerApp(
     private lateinit var server: RetrowarsServer
 
     override fun create() {
-        logger.info("Launching server app [port: ${config.port}, rooms: [type: ${config.rooms.getName()}, maxRooms: ${config.rooms.getMaxRooms()}, roomSize: ${config.rooms.getRoomSize()}], finalScoreDelayMillis: ${config.finalScoreDelayMillis}, inactivePlayerTimeoutMillis: ${config.inactivePlayerTimeoutMillis}]")
+        logger.info("Launching server app [port: ${config.port}, rooms: [type: ${config.rooms.getName()}, maxRooms: ${config.rooms.getMaxRooms()}, roomSize: ${config.rooms.getRoomSize()}], finalScoreDelayMillis: ${config.finalScoreDelayMillis}, inactivePlayerTimeoutMillis: ${config.inactivePlayerTimeoutMillis}, supportedGames: [${config.supportedGames.map { it.id }.joinToString(", ")}]]")
 
         server = RetrowarsServer(platform, config)
 

--- a/server/src/com/serwylo/retrowars/server/ServerLauncher.kt
+++ b/server/src/com/serwylo/retrowars/server/ServerLauncher.kt
@@ -5,17 +5,32 @@ import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration
 import com.serwylo.retrowars.net.Network
 import com.serwylo.retrowars.net.RetrowarsServer
 import com.serwylo.retrowars.utils.DesktopPlatform
+import kotlin.system.exitProcess
 
 object ServerLauncher {
+
+    val defaultMaxRooms = 20
+    val defaultRoomSize = 4
+    val defaultFinalScoreDurationMillis = 7500
+    val defaultInactivePlayerTimeout = 90000
 
     @JvmStatic
     fun main(args: Array<String>) {
 
+        val help = args.contains("--help") || args.contains("-h")
+        if (help) {
+            println("Usage: retrowars [--port=${Network.defaultPort}] [--max-rooms=${defaultMaxRooms}] [--room-size=${defaultRoomSize}] [--final-score-duration=${defaultFinalScoreDurationMillis}] [--inactive-player-timeout=${defaultInactivePlayerTimeout}] [--beta-games]\n" +
+                    "       retrowars --help\n" +
+                    "\n" +
+                    "Each argument can also be configured via a corresponding environment variable, e.g. PORT / MAX_ROOMS / ROOM_SIZE, etc.")
+            exitProcess(0)
+        }
+
         val port = getIntArg("PORT", "port", args) ?: Network.defaultPort
-        val maxRooms = getIntArg("MAX_ROOMS", "max-rooms", args) ?: 20
-        val roomSize = getIntArg("ROOM_SIZE", "room-size", args) ?: 4
-        val finalScoreDurationMillis = getIntArg("FINAL_SCORE_DURATION", "final-score-duration", args) ?: 7500
-        val inactivePlayerTimeoutMillis = getIntArg("INACTIVE_PLAYER_TIMEOUT", "inactive-player-timeout", args) ?: 90000
+        val maxRooms = getIntArg("MAX_ROOMS", "max-rooms", args) ?: defaultMaxRooms
+        val roomSize = getIntArg("ROOM_SIZE", "room-size", args) ?: defaultRoomSize
+        val finalScoreDurationMillis = getIntArg("FINAL_SCORE_DURATION", "final-score-duration", args) ?: defaultFinalScoreDurationMillis
+        val inactivePlayerTimeoutMillis = getIntArg("INACTIVE_PLAYER_TIMEOUT", "inactive-player-timeout", args) ?: defaultInactivePlayerTimeout
         val betaGames = getBoolArg("BETA_GAMES", "--beta-games", args)
 
         val serverConfig = RetrowarsServer.Config(


### PR DESCRIPTION
Use this feature by passing the `--supported-games` flag to the server (e.g. `--supported-games=tetris,asteroids`) or using the `SUPPORTED_GAMES` env var (e.g. `SUPPORTED_GAMES=tetris,asteroids`) when starting a server.