### PR TITLE
Server reports supported games via /info. Bump for release v0.32.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ allprojects {
         // in order for the F-Droid checkupdates bot to pick them up. Normally it just checks the
         // android apps build.gradle or AndroidManifest, but we dynamically inject them via these
         // properties so that both the server and the client have access to the same information.
-        appVersionCode = 66
-        appVersionName = "0.32.1"
+        appVersionCode = 67
+        appVersionName = "0.32.2"
 
         gdxVersion = '1.10.0'
         kotlinCoroutinesVersion = '1.4.2'

--- a/core/src/com/serwylo/retrowars/net/RetrowarsServer.kt
+++ b/core/src/com/serwylo/retrowars/net/RetrowarsServer.kt
@@ -310,6 +310,7 @@ class RetrowarsServer(private val platform: Platform, private val config: Config
     fun getPlayerCount() = rooms.getPlayerCount()
     fun getLastGameTime() = lastGame
     fun getLastPlayerTime() = lastPlayer
+    fun getSupportedGames() = config.supportedGames
 
     private var returnToLobbyTask: Job? = null
 
@@ -666,6 +667,7 @@ class WebSocketNetworkServer(
                             currentPlayerCount = retrowarsServer.getPlayerCount(),
                             lastGameTimestamp = retrowarsServer.getLastGameTime()?.time ?: -1,
                             lastPlayerTimestamp = retrowarsServer.getLastPlayerTime()?.time ?: ServerInfoDTO.LAST_PLAYER_TIMESTAMP_NEVER,
+                            supportedGames = retrowarsServer.getSupportedGames().map { it.id },
                         ))
                     }
                 }

--- a/core/src/com/serwylo/retrowars/net/ServerDirectory.kt
+++ b/core/src/com/serwylo/retrowars/net/ServerDirectory.kt
@@ -3,6 +3,7 @@ package com.serwylo.retrowars.net
 
 import com.badlogic.gdx.Gdx
 import com.google.gson.annotations.Since
+import com.serwylo.retrowars.games.Games
 import com.serwylo.retrowars.utils.AppProperties
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
@@ -43,6 +44,9 @@ data class ServerMetadataDTO(
  *
  * Version history:
  *  - 9 (v0.7.0) Initial support for online multiplayer.
+ *  - 67 (v0.32.2) Add "supported games". Each server can optionally specify only a subset of all
+ *                 games. Technically this happened in v0.32.1, but now we report the list of
+ *                 games via the "/info" endpoint.
  */
 data class ServerInfoDTO(
 
@@ -78,6 +82,9 @@ data class ServerInfoDTO(
 
     @Since(37.0)
     val lastPlayerTimestamp: Long = LAST_PLAYER_TIMESTAMP_NEVER,
+
+    @Since(67.0)
+    val supportedGames: List<String> = Games.allAvailable.map { it.id },
 
 ) {
     companion object {

--- a/fastlane/metadata/android/en-US/changelogs/67.txt
+++ b/fastlane/metadata/android/en-US/changelogs/67.txt
@@ -1,0 +1,2 @@
+Server changes only:
+ * "/info" endpoint now reports the games supported by the server.


### PR DESCRIPTION
It is hard to verify if a server is configured correctly because they were not reporting back what games they supported. This is now addressed by the server returning a list of supported games via `/info`.

See https://github.com/retrowars/retrowars-servers/pull/11#issuecomment-1926648814 for discussion.